### PR TITLE
Included <stdint.h> to make int32_t visible during Docker build with Clang on Alpine Linux.

### DIFF
--- a/source/nga.h
+++ b/source/nga.h
@@ -1,5 +1,8 @@
 #ifndef _NGA_H
 #define _NGA_H
+
+#include <stdint.h>
+
 #define CELL         int32_t
 #define IMAGE_SIZE   524288 * 16
 #define ADDRESSES    2048


### PR DESCRIPTION
Fixed width integer types are defined in `<stdint.h>` ([ref](http://en.cppreference.com/w/c/types/integer)) and on some platforms Clang reports them as undefined without including the header.