### PR TITLE
Fix style in the license file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
-RETRO
-a personal, minimalistic forth
+RETRO  
+a personal, minimalistic Forth
 
 ## Legalities
 


### PR DESCRIPTION
Capitalize Forth and add two spaces at the end of the "RETRO" line so that a new line is inserted when processed as Markdown (on GitHub for example).